### PR TITLE
✅ 🧪 receipt-analyze apiのテスト作成した

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ output/
 
 ## logs
 logs/
+
+# coverage reports
+.coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ dependencies = [
     "requests>=2.32.3",
     "opencv-python-headless>=4.10.0.84",
     "pydantic-settings>=2.10.1",
+    "pytest-mock>=3.14.1",
+    "coverage>=7.10.4",
 ]
 readme = "README.md"
 requires-python = ">= 3.11"

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -32,6 +32,8 @@ charset-normalizer==3.4.0
     # via requests
 click==8.1.7
     # via uvicorn
+coverage==7.10.4
+    # via receipt-scanner-model
 distlib==0.3.8
     # via virtualenv
 distro==1.9.0
@@ -94,6 +96,9 @@ pyright==1.1.378
 pytesseract==0.3.13
     # via receipt-scanner-model
 pytest==8.3.2
+    # via pytest-mock
+pytest-mock==3.14.1
+    # via receipt-scanner-model
 python-dateutil==2.9.0.post0
     # via botocore
 python-dotenv==1.0.1

--- a/requirements.lock
+++ b/requirements.lock
@@ -30,6 +30,8 @@ charset-normalizer==3.4.0
     # via requests
 click==8.1.7
     # via uvicorn
+coverage==7.10.4
+    # via receipt-scanner-model
 distro==1.9.0
     # via openai
 fastapi==0.114.0
@@ -47,6 +49,8 @@ idna==3.8
     # via anyio
     # via httpx
     # via requests
+iniconfig==2.1.0
+    # via pytest
 jiter==0.6.1
     # via openai
 jmespath==1.0.1
@@ -60,9 +64,12 @@ opencv-python-headless==4.10.0.84
     # via receipt-scanner-model
 packaging==24.1
     # via pytesseract
+    # via pytest
 pillow==10.4.0
     # via pytesseract
     # via receipt-scanner-model
+pluggy==1.6.0
+    # via pytest
 pydantic==2.9.0
     # via fastapi
     # via openai
@@ -71,7 +78,13 @@ pydantic-core==2.23.2
     # via pydantic
 pydantic-settings==2.10.1
     # via receipt-scanner-model
+pygments==2.19.2
+    # via pytest
 pytesseract==0.3.13
+    # via receipt-scanner-model
+pytest==8.4.1
+    # via pytest-mock
+pytest-mock==3.14.1
     # via receipt-scanner-model
 python-dateutil==2.9.0.post0
     # via botocore


### PR DESCRIPTION
## 概要
receipt-analyze apiのテスト作成した。

Closes #57 

## テストケース
- [正常系](https://github.com/ogaogs/receipt-scanner-model/issues/57#issuecomment-3200993446)
- [リクエスト形式に関するテスト](https://github.com/ogaogs/receipt-scanner-model/issues/57#issuecomment-3201189036)
- [S3関連のエラーが起きた際のテスト](https://github.com/ogaogs/receipt-scanner-model/issues/57#issuecomment-3201348102)
- [内部サーバーエラーと予期しない例外](https://github.com/ogaogs/receipt-scanner-model/issues/57#issuecomment-3201405052)
- [handle_receipt_exception関数の単体テスト](https://github.com/ogaogs/receipt-scanner-model/issues/57#issuecomment-3201465570)

## カバレッジ測定結果

カバレッジC1 100%

**C0のレポート**

``` sh
Name          Stmts   Miss  Cover   Missing
-------------------------------------------
api/main.py      39      0   100%
-------------------------------------------
TOTAL            39      0   100%
```

**C1のレポート**

``` sh
Name          Stmts   Miss Branch BrPart  Cover   Missing
---------------------------------------------------------
api/main.py      39      0      6      0   100%
---------------------------------------------------------
TOTAL            39      0      6      0   100%
```


## 注意

`test_empty_filename`は失敗している。
そのため、このテストをパスするために、リクエストのバリデーションを変更する必要がある。