### PR TITLE
receipt-analyze apiを修正して、テストが通るようにした

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -46,6 +46,9 @@ class FileName(BaseModel):
             validate_filename(value)
             return value
         except ValidationError as e:
+            logger.error(
+                f"無効なファイル名でエラーが発生しました。: {value}, reason: {str(e)}"
+            )
             raise ValueError("無効なファイル名です。") from e
 
 

--- a/api/main.py
+++ b/api/main.py
@@ -29,7 +29,7 @@ app = FastAPI(version=version)
 async def validation_exception_handler(request, exc: RequestValidationError):
     """RequestValidationErrorをHTTPExceptionの形に変換する"""
     logger.exception("レシート解析中にエラーが起きました。")
-    return HTTPException(
+    raise HTTPException(
         status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
         detail="レシート解析中にエラーが起きました。再度レシートをアップロードしてください。",
     )

--- a/api/main.py
+++ b/api/main.py
@@ -59,22 +59,22 @@ def handle_receipt_exception(e: Exception, filename: str | None):
 
     if isinstance(e, (S3BadRequest, S3NotFound)):
         return HTTPException(
-            status_code=400,
+            status_code=status.HTTP_400_BAD_REQUEST,
             detail="レシート解析中にエラーが起きました。再度レシートをアップロードしてください。",
         )
     elif isinstance(e, S3ServiceUnavailable):
         return HTTPException(
-            status_code=503,
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="レシート解析中にエラーが起きました。しばらくしてから再度お試しください。",
         )
     elif isinstance(e, (S3Forbidden, S3InternalServiceError)):
         return HTTPException(
-            status_code=500,
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="レシート解析中にエラーが起きました。開発者にお問い合わせください。",
         )
     else:
         return HTTPException(
-            status_code=500,
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="レシート解析中にエラーが起きました。開発者にお問い合わせください。",
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "pydantic-settings>=2.10.1",
     "pytest-mock>=3.14.1",
     "coverage>=7.10.4",
+    "pathvalidate>=3.3.1",
 ]
 readme = "README.md"
 requires-python = ">= 3.11"

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -76,6 +76,8 @@ opencv-python-headless==4.10.0.84
 packaging==24.1
     # via pytesseract
     # via pytest
+pathvalidate==3.3.1
+    # via receipt-scanner-model
 pillow==10.4.0
     # via pytesseract
     # via receipt-scanner-model

--- a/requirements.lock
+++ b/requirements.lock
@@ -65,6 +65,8 @@ opencv-python-headless==4.10.0.84
 packaging==24.1
     # via pytesseract
     # via pytest
+pathvalidate==3.3.1
+    # via receipt-scanner-model
 pillow==10.4.0
     # via pytesseract
     # via receipt-scanner-model


### PR DESCRIPTION
## 概要
1. リクエストのfilenameがからの場合に、422エラーが上がるようにした
2. Pydanticのエラーを他のエラーと同様のスタイルに統一し、ユーザーがわかりやすいエラーメッセージにした

## 動作確認
全てのテストが通ることを確認した

c1のカバレッジ測定
``` sh
Name          Stmts   Miss Branch BrPart  Cover   Missing
---------------------------------------------------------
api/main.py      51      0      8      0   100%
---------------------------------------------------------
TOTAL            51      0      8      0   100%
```