### PR TITLE
🐛 OpenAIの画像解析で、実際の画像タイプを使用するようにした(#79)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -120,9 +120,9 @@ def receipt_analyze(request: FileName) -> ReceiptDetail:
         s3_client = S3Client()
 
         # S3からファイル名を指定して画像をダウンロード
-        image_bytes = s3_client.download_image_by_filename(filename)
+        image_bytes, image_type = s3_client.download_image_by_filename(filename)
 
-        receipt_detail = get_receipt_detail(image_bytes)
+        receipt_detail = get_receipt_detail(image_bytes, image_type)
         return receipt_detail
     except Exception as e:
         raise handle_receipt_exception(e, filename)

--- a/src/receipt_scanner_model/__init__.py
+++ b/src/receipt_scanner_model/__init__.py
@@ -1,2 +1,0 @@
-def hello() -> str:
-    return "Hello from receipt-scanner-model!"

--- a/src/receipt_scanner_model/analyze.py
+++ b/src/receipt_scanner_model/analyze.py
@@ -2,15 +2,16 @@ from src.receipt_scanner_model.open_ai import OpenAIHandler, ReceiptDetail
 from src.receipt_scanner_model.file_operations import encode_image
 
 
-def get_receipt_detail(img_bytes: bytes) -> ReceiptDetail:
+def get_receipt_detail(img_bytes: bytes, image_type: str) -> ReceiptDetail:
     """レシートの解析を行い、ReceiptDetailを返す
 
     Args:
         img_bytes (bytes): ダウンロードした画像のバイトデータ
+        image_type (str): 画像のMIMEタイプ（例: "jpeg", "png"）
 
     Returns:
         ReceiptDetail: 店名、金額、日付、カテゴリー
     """
     openai_handler = OpenAIHandler()
     base64_image = encode_image(img_bytes)
-    return openai_handler.analyze_image(base64_image)
+    return openai_handler.analyze_image(base64_image, image_type)

--- a/src/receipt_scanner_model/open_ai.py
+++ b/src/receipt_scanner_model/open_ai.py
@@ -95,11 +95,12 @@ class OpenAIHandler:
         )
 
     @openai_error_handling
-    def analyze_image(self, base64_image: str):
+    def analyze_image(self, base64_image: str, image_type: str) -> ReceiptDetail:
         """OpenAIのAPIを呼び出し、レシートの解析を行う
 
         Args:
             base64_image (str): Base64エンコードされた画像データ
+            image_type (str): 画像のMIMEタイプ（例: "jpeg", "png"）
         Returns:
             ReceiptDetail: 解析されたレシートの詳細情報
         """
@@ -115,7 +116,9 @@ class OpenAIHandler:
             "content": [
                 {
                     "type": "image_url",
-                    "image_url": {"url": f"data:image/jpeg;base64,{base64_image}"},
+                    "image_url": {
+                        "url": f"data:image/{image_type};base64,{base64_image}"
+                    },
                 }
             ],
         }

--- a/src/receipt_scanner_model/scan_receipt.py
+++ b/src/receipt_scanner_model/scan_receipt.py
@@ -1,3 +1,5 @@
+"""レシートの画像から合計金額を取得するスクリプト。現在使用していない。"""
+
 from PIL import Image, ImageEnhance
 
 import cv2

--- a/tests/test_src/test_analyze.py
+++ b/tests/test_src/test_analyze.py
@@ -10,6 +10,7 @@ from src.receipt_scanner_model.error import (
 from src.receipt_scanner_model.analyze import get_receipt_detail
 
 TEST_IMAGE_BYTES = b"MockImageBytesForTesting"
+TEST_IMAGE_TYPE = "png"
 TEST_BASE64_IMAGE = "data:image/png;base64,MockImageDataForTesting"
 
 
@@ -42,7 +43,7 @@ def test_get_receipt_detail_success(
 ):
     mock_openai_handler.analyze_image.return_value = test_receipt_detail
 
-    result = get_receipt_detail(TEST_IMAGE_BYTES)
+    result = get_receipt_detail(TEST_IMAGE_BYTES, TEST_IMAGE_TYPE)
 
     assert result.store_name == test_receipt_detail.store_name
     assert result.date == test_receipt_detail.date
@@ -86,7 +87,7 @@ def test_get_receipt_detail_error_handling(
     )
 
     with pytest.raises(exception) as exc_info:
-        get_receipt_detail(TEST_IMAGE_BYTES)
+        get_receipt_detail(TEST_IMAGE_BYTES, TEST_IMAGE_TYPE)
 
     assert exc_info.value.code == status_code
     assert exc_info.value.message == expected_message

--- a/tests/test_src/test_openai.py
+++ b/tests/test_src/test_openai.py
@@ -21,6 +21,7 @@ from openai import (
 )
 
 TEST_BASE64_IMAGE = "data:image/png;base64,MockImageDataForTesting"
+TEST_IMAGE_TYPE = "png"
 
 
 def create_mock_completion(parsed_data=None):
@@ -81,7 +82,7 @@ def test_analyze_image_success(
     mock_openai_client.beta.chat.completions.parse.return_value = mock_openai_result
 
     openai_handler = OpenAIHandler()
-    result = openai_handler.analyze_image(TEST_BASE64_IMAGE)
+    result = openai_handler.analyze_image(TEST_BASE64_IMAGE, TEST_IMAGE_TYPE)
 
     assert result.store_name == test_receipt_detail.store_name
     assert result.date == test_receipt_detail.date
@@ -105,7 +106,7 @@ def test_analyze_image_response_format_error(mock_openai_client):
 
     openai_handler = OpenAIHandler()
     with pytest.raises(OpenAIResponseFormatError) as exc_info:
-        openai_handler.analyze_image(TEST_BASE64_IMAGE)
+        openai_handler.analyze_image(TEST_BASE64_IMAGE, TEST_IMAGE_TYPE)
 
     assert exc_info.value.code == 503
     assert exc_info.value.message == "OpenAIの応答の解析に失敗しました。"
@@ -179,7 +180,7 @@ def test_analyze_image_error_handling(
 
     openai_handler = OpenAIHandler()
     with pytest.raises(expected_exception) as exc_info:
-        openai_handler.analyze_image(TEST_BASE64_IMAGE)
+        openai_handler.analyze_image(TEST_BASE64_IMAGE, TEST_IMAGE_TYPE)
 
     assert exc_info.value.code == status_code
     assert exc_info.value.message == expected_message

--- a/tests/test_src/test_s3_client.py
+++ b/tests/test_src/test_s3_client.py
@@ -292,3 +292,24 @@ def test_unexpected_error(mock_aws_s3_client, s3_client, exception_type, error_m
 
     assert exc_info.value.code == 500
     assert "ダウンロード中に予期しないエラーが発生しました" in exc_info.value.message
+
+
+@pytest.mark.parametrize(
+    "file_name, content_type",
+    [
+        ("test_file.pdf", "application/pdf"),
+        ("test_file.gif", "image/gif"),
+    ],
+)
+def test_invalid_content_type(file_name, content_type, mock_aws_s3_client, s3_client):
+    """Content-Typeが画像でない場合のテスト（lines 68-74のカバレッジ）"""
+
+    mock_aws_s3_client.head_object.return_value = {
+        "ContentLength": 1024,
+        "ContentType": content_type,
+    }
+
+    with pytest.raises(S3BadRequest) as exc_info:
+        s3_client.download_image_by_filename(file_name)
+
+    assert exc_info.value.code == 400

--- a/tests/test_src/test_scan_receipt.py
+++ b/tests/test_src/test_scan_receipt.py
@@ -1,3 +1,5 @@
+"""src/receipt_scanner_model/scan_receipt.pyは現在使用していない。"""
+
 import os
 from src.receipt_scanner_model import scan_receipt
 from PIL import Image


### PR DESCRIPTION
## 概要
OpenAIの画像解析で、実際の画像タイプを使用できるようにした。

上記の伴い、テストの修正と、コンテントタイプに関するテストを追加した。

## 動作確認
実際の画像が解析できることを確認した。

c1カバレッジ測定
``` sh

``` sh
Name                                           Stmts   Miss Branch BrPart  Cover   Missing
------------------------------------------------------------------------------------------
api/main.py                                       56      0      8      0   100%
src/receipt_scanner_model/__init__.py              0      0      0      0   100%
src/receipt_scanner_model/analyze.py               6      0      0      0   100%
src/receipt_scanner_model/error.py                24      0      0      0   100%
src/receipt_scanner_model/file_operations.py       3      0      0      0   100%
src/receipt_scanner_model/logger_config.py        33      0      2      0   100%
src/receipt_scanner_model/open_ai.py              50      0      2      0   100%
src/receipt_scanner_model/s3_client.py            57      0     18      0   100%
src/receipt_scanner_model/scan_receipt.py         78      6     28      7    88%   75->exit, 108, 119, 124, 145-146, 173->167, 179
src/receipt_scanner_model/setting.py               9      0      0      0   100%
------------------------------------------------------------------------------------------
TOTAL                                            316      6     58      7    97%
```