### PR TITLE
🥅 エラーリスポンスにErrorCodeを追加した (#77)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Run tests with coverage
         run: rye run coverage run --branch -m pytest tests
       - name: Generate coverage XML
-        run: rye run coverage xml --include="api/*,src/*"
+        run: rye run coverage xml --include="api/*,src/*" --omit="src/receipt_scanner_model/scan_receipt.py"
       - name: Pytest coverage comment
         uses: MishaKav/pytest-coverage-comment@main
         with:

--- a/api/main.py
+++ b/api/main.py
@@ -1,13 +1,15 @@
-from fastapi import FastAPI, HTTPException, status
+from fastapi import FastAPI, status
 from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
 from src.receipt_scanner_model.analyze import ReceiptDetail, get_receipt_detail
-from src.receipt_scanner_model.s3_client import S3Client
+from src.receipt_scanner_model.s3_client import S3Client, MAX_FILE_SIZE
 from src.receipt_scanner_model.logger_config import set_logger
 import tomllib
 import logging
 from pydantic import BaseModel, field_validator
 from src.receipt_scanner_model.error import (
-    S3BadRequest,
+    ContentSizeError,
+    InvalidContentTypeError,
     S3NotFound,
     S3Forbidden,
     S3ServiceUnavailable,
@@ -15,6 +17,8 @@ from src.receipt_scanner_model.error import (
     OpenAIAuthenticationError,
     OpenAIServiceUnavailable,
     OpenAIResponseFormatError,
+    CustomHTTPException,
+    ErrorCode,
 )
 from pathvalidate import ValidationError, validate_filename
 
@@ -29,13 +33,26 @@ with open("pyproject.toml", "rb") as f:
 app = FastAPI(version=version)
 
 
+@app.exception_handler(CustomHTTPException)
+async def custom_exception_handler(request, exc: CustomHTTPException):
+    """CustomHTTPExceptionを構造化されたエラーレスポンスに変換する"""
+    return JSONResponse(
+        status_code=exc.http_status_code,
+        content={
+            "error_type_code": exc.error_type_code.value,
+            "message": exc.message,
+        },
+    )
+
+
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(request, exc: RequestValidationError):
     """RequestValidationErrorをHTTPExceptionの形に変換する"""
     logger.exception("レシート解析中にエラーが起きました。")
-    raise HTTPException(
-        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-        detail="レシート解析中にエラーが起きました。再度レシートをアップロードしてください。",
+    raise CustomHTTPException(
+        http_status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        error_type_code=ErrorCode.CLIENT_ERROR,
+        message="リクエストのバリデーションに失敗しました。入力内容を確認してください。",
     )
 
 
@@ -44,54 +61,69 @@ class FileName(BaseModel):
 
     @field_validator("filename")
     @classmethod
-    def validate_filename(cls, value: str) -> str:
+    def check_filename(cls, value: str) -> str:
         try:
             validate_filename(value)
             return value
         except ValidationError as e:
-            logger.error(
-                f"無効なファイル名でエラーが発生しました。: {value}, reason: {str(e)}"
-            )
-            raise ValueError("無効なファイル名です。") from e
+            logger.error(f"無効なファイル名でエラーが発生しました。 {value}: {str(e)}")
+            raise ValueError(f"無効なファイル名です。 {value}: {str(e)}")
 
 
 def handle_receipt_exception(e: Exception, filename: str | None):
-    """例外を分類してHTTPExceptionに変換する
+    """例外を分類してCustomHTTPExceptionに変換する
 
     Args:
         e: キャッチされた例外
 
     Returns:
-        HTTPException: 適切なステータスコードとメッセージを持つHTTPException
+        CustomHTTPException: 構造化されたエラーレスポンスを持つCustomHTTPException
     """
     logger.exception(f"レシート解析中にエラーが起きました。ファイル名: {filename}")
 
-    if isinstance(e, (S3BadRequest, S3NotFound)):
-        return HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="レシート解析中にエラーが起きました。再度レシートをアップロードしてください。",
+    if isinstance(e, ContentSizeError):
+        return CustomHTTPException(
+            http_status_code=status.HTTP_400_BAD_REQUEST,
+            error_type_code=ErrorCode.SIZE_ERROR,
+            message=f"ダウンロードした画像サイズが0バイト以下か、{MAX_FILE_SIZE}より大きいです。ファイル名: {filename}",
+        )
+    if isinstance(e, InvalidContentTypeError):
+        return CustomHTTPException(
+            http_status_code=status.HTTP_400_BAD_REQUEST,
+            error_type_code=ErrorCode.INVALID_TYPE,
+            message=f"ダウンロードした画像のContent-Typeが不正です。ファイル名: {filename}",
+        )
+    elif isinstance(e, S3NotFound):
+        return CustomHTTPException(
+            http_status_code=status.HTTP_404_NOT_FOUND,
+            error_type_code=ErrorCode.CLIENT_ERROR,
+            message=f"指定されたファイル名({filename})が見つかりません。ファイルアップロードに問題がある可能性があります。",
+        )
+    elif isinstance(e, OpenAIResponseFormatError):
+        return CustomHTTPException(
+            http_status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            error_type_code=ErrorCode.SERVER_ERROR,
+            message="解析結果が予期せぬ形式でした。再度解析をすることで、正常に動作する場合があります。問題が継続する場合は、サポートまでお問い合わせください。",
         )
     elif isinstance(
-        e, (S3ServiceUnavailable, OpenAIServiceUnavailable, OpenAIResponseFormatError)
+        e, (S3ServiceUnavailable, S3InternalServerError, OpenAIServiceUnavailable)
     ):
-        return HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="レシート解析中にエラーが起きました。しばらくしてから再度お試しください。",
-        )
-    elif isinstance(e, S3InternalServerError):
-        return HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="レシート解析中にエラーが起きました。しばらくしてから再度お試しください。",
+        return CustomHTTPException(
+            http_status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            error_type_code=ErrorCode.SERVER_ERROR,
+            message="S3またはOpenAIのサービスが一時的に利用できません。時間をおいて再度お試しください。",
         )
     elif isinstance(e, (S3Forbidden, OpenAIAuthenticationError)):
-        return HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="レシート解析中にエラーが起きました。サポートまでお問い合わせください",
+        return CustomHTTPException(
+            http_status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            error_type_code=ErrorCode.SERVER_ERROR,
+            message="レシート解析中に権限エラーが起きました。",
         )
-    else:  # S3UnexpectedError, OpenAIUnexpectedErrorその他のエラー
-        return HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="レシート解析中にエラーが起きました。しばらくしてから再度お試しください。問題が継続する場合は、サポートまでお問い合わせください",
+    else:  # S3BadRequest, OpenAIUnexpectedError, S3UnexpectedErrorを含むその他のエラー
+        return CustomHTTPException(
+            http_status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            error_type_code=ErrorCode.SERVER_ERROR,
+            message="レシート解析中にエラーが起きました。しばらくしてから再度お試しください。問題が継続する場合は、サポートまでお問い合わせください",
         )
 
 

--- a/src/receipt_scanner_model/error.py
+++ b/src/receipt_scanner_model/error.py
@@ -1,46 +1,76 @@
+from enum import Enum
+
+
+class ErrorCode(Enum):
+    """エラータイプ：SIZE_ERROR, INVALID_TYPEは400系に含まれるが、細かく分類するために分けている"""
+
+    SIZE_ERROR = "size_error"  # 画像サイズエラー
+    INVALID_TYPE = "invalid_type"  # 画像タイプエラー
+    CLIENT_ERROR = "client_error"  # 400系
+    SERVER_ERROR = "server_error"  # 500系
+
+
+class CustomHTTPException(Exception):
+    """カスタムHTTPException：構造化されたエラーレスポンスを返すため"""
+
+    def __init__(self, http_status_code: int, error_type_code: ErrorCode, message: str):
+        self.http_status_code = http_status_code
+        self.error_type_code = error_type_code
+        self.message = message
+        super().__init__(message)
+
+
 class ErrorResponse(Exception):
-    def __init__(self, code: int, message: str):
-        self.code = code
+    def __init__(self, status_code: int, error_type_code: ErrorCode, message: str):
+        self.status_code = status_code
+        self.error_type_code = error_type_code
         self.message = message
 
 
-# 400系でクライアントに返す
-class S3BadRequest(ErrorResponse):
+class ContentSizeError(Exception):
     pass
 
 
-class S3NotFound(ErrorResponse):
+class InvalidContentTypeError(Exception):
+    pass
+
+
+class S3BadRequest(Exception):
+    pass
+
+
+class S3NotFound(Exception):
     pass
 
 
 # 500系でクライアントに返す
-class S3Forbidden(ErrorResponse):
+class S3Forbidden(Exception):
     pass
 
 
-class S3ServiceUnavailable(ErrorResponse):
+class S3ServiceUnavailable(Exception):
     pass
 
 
-class S3InternalServerError(ErrorResponse):
+class S3InternalServerError(Exception):
     pass
 
 
-class S3UnexpectedError(ErrorResponse):
+class S3UnexpectedError(Exception):
     pass
 
 
-class OpenAIAuthenticationError(ErrorResponse):
+class OpenAIAuthenticationError(Exception):
     pass
 
 
-class OpenAIServiceUnavailable(ErrorResponse):
+class OpenAIServiceUnavailable(Exception):
     pass
 
 
-class OpenAIUnexpectedError(ErrorResponse):
+class OpenAIUnexpectedError(Exception):
     pass
 
 
-class OpenAIResponseFormatError(ErrorResponse):
+class OpenAIResponseFormatError(Exception):
     pass

--- a/src/receipt_scanner_model/error.py
+++ b/src/receipt_scanner_model/error.py
@@ -20,13 +20,6 @@ class CustomHTTPException(Exception):
         super().__init__(message)
 
 
-class ErrorResponse(Exception):
-    def __init__(self, status_code: int, error_type_code: ErrorCode, message: str):
-        self.status_code = status_code
-        self.error_type_code = error_type_code
-        self.message = message
-
-
 class ContentSizeError(Exception):
     pass
 

--- a/src/receipt_scanner_model/open_ai.py
+++ b/src/receipt_scanner_model/open_ai.py
@@ -64,21 +64,22 @@ def openai_error_handling(func):
         except (AuthenticationError, PermissionDeniedError) as e:
             logger.error(f"OpenAIの認証エラー: {str(e)}")
             raise OpenAIAuthenticationError(
-                401, "OpenAIの認証に失敗しました。APIキーを確認してください。"
+                "OpenAIの認証に失敗しました。APIキーを確認してください。"
             )
         except (
             APITimeoutError,
             RateLimitError,
             InternalServerError,
         ) as e:
-            logger.error(f"OpenAIの一時的なエラー: {str(e)}")
+            logger.error(f"OpenAI Completions APIでエラーが発生しました: {str(e)}")
             raise OpenAIServiceUnavailable(
-                503,
-                "OpenAIのサービスが一時的に利用できません。時間をおいて再度お試しください。",
+                f"OpenAI Completions APIでエラーが発生しました: {str(e)}",
             )
         except Exception as e:
             logger.error(f"OpenAIの予期しないエラー: {str(e)}")
-            raise OpenAIUnexpectedError(500, "OpenAIの予期しないエラーが発生しました。")
+            raise OpenAIUnexpectedError(
+                f"OpenAIの予期しないエラーが発生しました。: {str(e)}"
+            )
 
     return wrapper
 
@@ -128,7 +129,5 @@ class OpenAIHandler:
         )
         output = response.choices[0].message.parsed
         if not isinstance(output, ReceiptDetail):
-            raise OpenAIResponseFormatError(
-                code=503, message="OpenAIの応答の解析に失敗しました。"
-            )
+            raise OpenAIResponseFormatError("OpenAIのレスポンス形式が不正です")
         return output

--- a/src/receipt_scanner_model/s3_client.py
+++ b/src/receipt_scanner_model/s3_client.py
@@ -5,6 +5,8 @@ import logging
 from src.receipt_scanner_model.setting import setting
 from botocore.exceptions import ClientError
 from src.receipt_scanner_model.error import (
+    ContentSizeError,
+    InvalidContentTypeError,
     S3BadRequest,
     S3NotFound,
     S3Forbidden,
@@ -52,15 +54,15 @@ class S3Client:
 
             if content_length <= 0:
                 logger.error(f"ファイルサイズが0バイト以下です: {content_length} bytes")
-                raise S3BadRequest(
-                    400, f"ファイルサイズが0バイト以下です: {content_length} bytes"
+                raise ContentSizeError(
+                    f"ファイルサイズが0バイト以下です: {content_length} bytes"
                 )
             elif content_length > max_size:
                 logger.error(
                     f"ファイルサイズが制限を超えています: {content_length} bytes"
                 )
-                raise S3BadRequest(
-                    400, f"ファイルサイズが制限を超えています: {content_length} bytes"
+                raise ContentSizeError(
+                    f"ファイルサイズが制限を超えています: {content_length} bytes"
                 )
 
             content_type = head_response.get("ContentType", None)
@@ -69,13 +71,13 @@ class S3Client:
                 logger.error(
                     f"ファイルのContent-Typeが画像ではありません: {content_type}"
                 )
-                raise S3BadRequest(
-                    400, f"ファイルのContent-Typeが画像ではありません: {content_type}"
+                raise InvalidContentTypeError(
+                    f"ファイルのContent-Typeが画像ではありません: {content_type}"
                 )
             if content_type not in ["image/png", "image/jpeg"]:
                 logger.error(f"サポートされていない画像形式です: {content_type}")
-                raise S3BadRequest(
-                    400, f"サポートされていない画像形式です: {content_type}"
+                raise InvalidContentTypeError(
+                    f"サポートされていない画像形式です: {content_type}"
                 )
 
             # サイズ・画像タイプに問題なければダウンロード
@@ -94,50 +96,46 @@ class S3Client:
                     f"不正なリクエストです: {http_status_code} {error_message}"
                 )
                 raise S3BadRequest(
-                    http_status_code,
-                    f"不正なリクエストです: {error_message}",
+                    f"不正なリクエストです: {http_status_code} {error_message}"
                 )
             elif http_status_code == 404:
                 logger.error(
                     f"指定されたファイルがS3にありません: {http_status_code} {error_message}"
                 )
                 raise S3NotFound(
-                    http_status_code,
-                    f"指定されたファイルがS3にありません: {error_message}",
+                    f"指定されたファイルがS3にありません: {http_status_code} {error_message}"
                 )
             elif http_status_code == 403:
                 logger.error(
                     f"アクセスが拒否されました: {http_status_code} {error_message}"
                 )
                 raise S3Forbidden(
-                    http_status_code,
-                    f"アクセスが拒否されました: {error_message}",
+                    f"アクセスが拒否されました: {http_status_code} {error_message}"
                 )
             elif http_status_code == 503:
                 logger.error(
                     f"S3サービスが一時的に利用できません: {http_status_code} {error_message}"
                 )
                 raise S3ServiceUnavailable(
-                    http_status_code,
-                    f"S3サービスが一時的に利用できません: {error_message}",
+                    f"S3サービスが一時的に利用できません: {http_status_code} {error_message}"
                 )
             elif http_status_code == 500:
                 logger.error(
                     f"S3サービスでInternalServerErrorが発生しました: {http_status_code} {error_message}"
                 )
                 raise S3InternalServerError(
-                    http_status_code,
-                    f"S3サービスでInternalServerErrorが発生しました: {error_message}",
+                    f"S3サービスでInternalServerErrorが発生しました: {http_status_code} {error_message}"
                 )
             else:
                 logger.error(
                     f"ダウンロード中に予期しないエラーが発生しました: {http_status_code} {error_message}"
                 )
                 raise S3UnexpectedError(
-                    http_status_code,
-                    f"ダウンロード中に予期しないエラーが発生しました: {error_message}",
+                    f"ダウンロード中に予期しないエラーが発生しました: {http_status_code} {error_message}"
                 )
-        except S3BadRequest:
+        except ContentSizeError:
+            raise
+        except InvalidContentTypeError:
             raise
         except Exception as e:
             logger.error(f"ダウンロード中に予期しないエラーが発生しました: {e}")

--- a/src/receipt_scanner_model/s3_client.py
+++ b/src/receipt_scanner_model/s3_client.py
@@ -140,5 +140,5 @@ class S3Client:
         except Exception as e:
             logger.error(f"ダウンロード中に予期しないエラーが発生しました: {e}")
             raise S3UnexpectedError(
-                500, f"ダウンロード中に予期しないエラーが発生しました: {e}"
+                f"ダウンロード中に予期しないエラーが発生しました: {e}"
             )

--- a/tests/test_api/test_main.py
+++ b/tests/test_api/test_main.py
@@ -4,12 +4,19 @@ import pytest
 
 from api.main import app, S3Client, handle_receipt_exception
 from src.receipt_scanner_model.error import (
+    ContentSizeError,
+    InvalidContentTypeError,
     S3BadRequest,
     S3NotFound,
     S3Forbidden,
     S3ServiceUnavailable,
     S3InternalServerError,
     S3UnexpectedError,
+    ErrorCode,
+    OpenAIResponseFormatError,
+    OpenAIServiceUnavailable,
+    OpenAIAuthenticationError,
+    OpenAIUnexpectedError,
 )
 import tomllib
 
@@ -112,29 +119,29 @@ class TestInputValidation:
         """filenameフィールドが欠落"""
         response = client.post("/receipt-analyze", json={})
         assert response.status_code == 422
-        assert (
-            response.json()["detail"]
-            == "レシート解析中にエラーが起きました。再度レシートをアップロードしてください。"
-        )
+        assert response.json() == {
+            "error_type_code": ErrorCode.CLIENT_ERROR.value,
+            "message": "リクエストのバリデーションに失敗しました。入力内容を確認してください。",
+        }
 
     @pytest.mark.parametrize("empty_filename", ["", "   "])
     def test_empty_filename(self, client: TestClient, empty_filename):
         """filenameが空文字列"""
         response = client.post("/receipt-analyze", json={"filename": empty_filename})
         assert response.status_code == 422
-        assert (
-            response.json()["detail"]
-            == "レシート解析中にエラーが起きました。再度レシートをアップロードしてください。"
-        )
+        assert response.json() == {
+            "error_type_code": ErrorCode.CLIENT_ERROR.value,
+            "message": "リクエストのバリデーションに失敗しました。入力内容を確認してください。",
+        }
 
     def test_null_filename(self, client: TestClient):
         """filenameがnull"""
         response = client.post("/receipt-analyze", json={"filename": None})
         assert response.status_code == 422
-        assert (
-            response.json()["detail"]
-            == "レシート解析中にエラーが起きました。再度レシートをアップロードしてください。"
-        )
+        assert response.json() == {
+            "error_type_code": ErrorCode.CLIENT_ERROR.value,
+            "message": "リクエストのバリデーションに失敗しました。入力内容を確認してください。",
+        }
 
     @pytest.mark.parametrize(
         "invalid_filename", [123, [], {}, True, [TEST_FILE_NAME], 1.5]
@@ -143,10 +150,10 @@ class TestInputValidation:
         """filenameが文字列以外"""
         response = client.post("/receipt-analyze", json={"filename": invalid_filename})
         assert response.status_code == 422
-        assert (
-            response.json()["detail"]
-            == "レシート解析中にエラーが起きました。再度レシートをアップロードしてください。"
-        )
+        assert response.json() == {
+            "error_type_code": ErrorCode.CLIENT_ERROR.value,
+            "message": "リクエストのバリデーションに失敗しました。入力内容を確認してください。",
+        }
 
     def test_invalid_json_format(self, client: TestClient):
         """不正なJSONフォーマット"""
@@ -156,10 +163,10 @@ class TestInputValidation:
             headers={"Content-Type": "application/json"},
         )
         assert response.status_code == 422
-        assert (
-            response.json()["detail"]
-            == "レシート解析中にエラーが起きました。再度レシートをアップロードしてください。"
-        )
+        assert response.json() == {
+            "error_type_code": ErrorCode.CLIENT_ERROR.value,
+            "message": "リクエストのバリデーションに失敗しました。入力内容を確認してください。",
+        }
 
     def test_invalid_content_type(self, client: TestClient):
         """Content-Typeが不正"""
@@ -169,10 +176,10 @@ class TestInputValidation:
             headers={"Content-Type": "text/plain"},
         )
         assert response.status_code == 422
-        assert (
-            response.json()["detail"]
-            == "レシート解析中にエラーが起きました。再度レシートをアップロードしてください。"
-        )
+        assert response.json() == {
+            "error_type_code": ErrorCode.CLIENT_ERROR.value,
+            "message": "リクエストのバリデーションに失敗しました。入力内容を確認してください。",
+        }
 
     @pytest.mark.parametrize(
         "invalid_filename",
@@ -189,10 +196,10 @@ class TestInputValidation:
         """危険なファイル名パターンのテスト"""
         response = client.post("/receipt-analyze", json={"filename": invalid_filename})
         assert response.status_code == 422
-        assert (
-            response.json()["detail"]
-            == "レシート解析中にエラーが起きました。再度レシートをアップロードしてください。"
-        )
+        assert response.json() == {
+            "error_type_code": ErrorCode.CLIENT_ERROR.value,
+            "message": "リクエストのバリデーションに失敗しました。入力内容を確認してください。",
+        }
 
 
 class TestS3ErrorHandling:
@@ -205,32 +212,33 @@ class TestS3ErrorHandling:
         mocker.patch.object(
             S3Client,
             "download_image_by_filename",
-            side_effect=S3BadRequest(400, "Bad request"),
+            side_effect=S3BadRequest,
         )
 
         response = client.post("/receipt-analyze", json={"filename": TEST_FILE_NAME})
 
-        assert response.status_code == 400
-        assert (
-            response.json()["detail"]
-            == "レシート解析中にエラーが起きました。再度レシートをアップロードしてください。"
-        )
+        assert response.status_code == 500
+        assert response.json() == {
+            "error_type_code": ErrorCode.SERVER_ERROR.value,
+            "message": "レシート解析中にエラーが起きました。しばらくしてから再度お試しください。問題が継続する場合は、サポートまでお問い合わせください",
+        }
 
     def test_s3_not_found_exception(self, client: TestClient, mocker: MockFixture):
         """S3NotFound例外"""
+        filename = "not_exists.jpg"
         mocker.patch.object(
             S3Client,
             "download_image_by_filename",
-            side_effect=S3NotFound(404, "Not found"),
+            side_effect=S3NotFound,
         )
 
-        response = client.post("/receipt-analyze", json={"filename": "not_exists.jpg"})
+        response = client.post("/receipt-analyze", json={"filename": filename})
 
-        assert response.status_code == 400
-        assert (
-            response.json()["detail"]
-            == "レシート解析中にエラーが起きました。再度レシートをアップロードしてください。"
-        )
+        assert response.status_code == 404
+        assert response.json() == {
+            "error_type_code": ErrorCode.CLIENT_ERROR.value,
+            "message": f"指定されたファイル名({filename})が見つかりません。ファイルアップロードに問題がある可能性があります。",
+        }
 
     def test_s3_service_unavailable_exception(
         self, client: TestClient, mocker: MockFixture
@@ -239,32 +247,32 @@ class TestS3ErrorHandling:
         mocker.patch.object(
             S3Client,
             "download_image_by_filename",
-            side_effect=S3ServiceUnavailable(503, "Service unavailable"),
+            side_effect=S3ServiceUnavailable,
         )
 
         response = client.post("/receipt-analyze", json={"filename": TEST_FILE_NAME})
 
         assert response.status_code == 503
-        assert (
-            response.json()["detail"]
-            == "レシート解析中にエラーが起きました。しばらくしてから再度お試しください。"
-        )
+        assert response.json() == {
+            "error_type_code": ErrorCode.SERVER_ERROR.value,
+            "message": "S3またはOpenAIのサービスが一時的に利用できません。時間をおいて再度お試しください。",
+        }
 
     def test_s3_forbidden_exception(self, client: TestClient, mocker: MockFixture):
         """S3Forbidden例外（権限不足）"""
         mocker.patch.object(
             S3Client,
             "download_image_by_filename",
-            side_effect=S3Forbidden(403, "Forbidden"),
+            side_effect=S3Forbidden,
         )
 
         response = client.post("/receipt-analyze", json={"filename": TEST_FILE_NAME})
 
         assert response.status_code == 500
-        assert (
-            response.json()["detail"]
-            == "レシート解析中にエラーが起きました。サポートまでお問い合わせください"
-        )
+        assert response.json() == {
+            "error_type_code": ErrorCode.SERVER_ERROR.value,
+            "message": "レシート解析中に権限エラーが起きました。",
+        }
 
     def test_s3_internal_service_error_exception(
         self, client: TestClient, mocker: MockFixture
@@ -273,16 +281,16 @@ class TestS3ErrorHandling:
         mocker.patch.object(
             S3Client,
             "download_image_by_filename",
-            side_effect=S3InternalServerError(500, "Internal error"),
+            side_effect=S3InternalServerError,
         )
 
         response = client.post("/receipt-analyze", json={"filename": TEST_FILE_NAME})
 
-        assert response.status_code == 500
-        assert (
-            response.json()["detail"]
-            == "レシート解析中にエラーが起きました。しばらくしてから再度お試しください。"
-        )
+        assert response.status_code == 503
+        assert response.json() == {
+            "error_type_code": ErrorCode.SERVER_ERROR.value,
+            "message": "S3またはOpenAIのサービスが一時的に利用できません。時間をおいて再度お試しください。",
+        }
 
     def test_s3_unexpected_error_exception(
         self, client: TestClient, mocker: MockFixture
@@ -291,16 +299,16 @@ class TestS3ErrorHandling:
         mocker.patch.object(
             S3Client,
             "download_image_by_filename",
-            side_effect=S3UnexpectedError(500, "Unexpected error"),
+            side_effect=S3UnexpectedError,
         )
 
         response = client.post("/receipt-analyze", json={"filename": TEST_FILE_NAME})
 
         assert response.status_code == 500
-        assert (
-            response.json()["detail"]
-            == "レシート解析中にエラーが起きました。しばらくしてから再度お試しください。問題が継続する場合は、サポートまでお問い合わせください"
-        )
+        assert response.json() == {
+            "error_type_code": ErrorCode.SERVER_ERROR.value,
+            "message": "レシート解析中にエラーが起きました。しばらくしてから再度お試しください。問題が継続する場合は、サポートまでお問い合わせください",
+        }
 
 
 class TestInternalServerErrors:
@@ -319,10 +327,10 @@ class TestInternalServerErrors:
         response = client.post("/receipt-analyze", json={"filename": TEST_FILE_NAME})
 
         assert response.status_code == 500
-        assert (
-            response.json()["detail"]
-            == "レシート解析中にエラーが起きました。しばらくしてから再度お試しください。問題が継続する場合は、サポートまでお問い合わせください"
-        )
+        assert response.json() == {
+            "error_type_code": ErrorCode.SERVER_ERROR.value,
+            "message": "レシート解析中にエラーが起きました。しばらくしてから再度お試しください。問題が継続する場合は、サポートまでお問い合わせください",
+        }
 
     def test_s3_client_initialization_failure(
         self, client: TestClient, mocker: MockFixture
@@ -335,13 +343,12 @@ class TestInternalServerErrors:
         response = client.post("/receipt-analyze", json={"filename": TEST_FILE_NAME})
 
         assert response.status_code == 500
-        assert (
-            response.json()["detail"]
-            == "レシート解析中にエラーが起きました。しばらくしてから再度お試しください。問題が継続する場合は、サポートまでお問い合わせください"
-        )
+        assert response.json() == {
+            "error_type_code": ErrorCode.SERVER_ERROR.value,
+            "message": "レシート解析中にエラーが起きました。しばらくしてから再度お試しください。問題が継続する場合は、サポートまでお問い合わせください",
+        }
 
     def test_get_receipt_detail_failure(self, client: TestClient, mocker: MockFixture):
-        # FIXME get_receipt_detailのエラーハンドリングを整備後に詳細なテストが必要。
         """get_receipt_detail関数でのエラー"""
         mocker.patch.object(
             S3Client, "download_image_by_filename", return_value=MOCK_IMAGE_BYTES
@@ -354,10 +361,10 @@ class TestInternalServerErrors:
         response = client.post("/receipt-analyze", json={"filename": TEST_FILE_NAME})
 
         assert response.status_code == 500
-        assert (
-            response.json()["detail"]
-            == "レシート解析中にエラーが起きました。しばらくしてから再度お試しください。問題が継続する場合は、サポートまでお問い合わせください"
-        )
+        assert response.json() == {
+            "error_type_code": ErrorCode.SERVER_ERROR.value,
+            "message": "レシート解析中にエラーが起きました。しばらくしてから再度お試しください。問題が継続する場合は、サポートまでお問い合わせください",
+        }
 
 
 class TestHandleReceiptException:
@@ -365,90 +372,112 @@ class TestHandleReceiptException:
     handle_receipt_exception関数の単体テスト
     """
 
-    def test_handle_s3_bad_request(self):
-        """S3BadRequest例外の処理"""
-        exception = S3BadRequest(400, "Bad request")
+    def test_handle_content_size_error(self):
+        """ContentSizeError例外の処理"""
+        exception = ContentSizeError()
         result = handle_receipt_exception(exception, TEST_FILE_NAME)
 
-        assert result.status_code == 400
+        assert result.http_status_code == 400
+        assert result.error_type_code == ErrorCode.SIZE_ERROR
         assert (
-            result.detail
-            == "レシート解析中にエラーが起きました。再度レシートをアップロードしてください。"
+            result.message
+            == f"ダウンロードした画像サイズが0バイト以下か、5242880より大きいです。ファイル名: {TEST_FILE_NAME}"
+        )
+
+    def test_handle_invalid_content_type_error(self):
+        """InvalidContentTypeError例外の処理"""
+        exception = InvalidContentTypeError()
+        result = handle_receipt_exception(exception, TEST_FILE_NAME)
+
+        assert result.http_status_code == 400
+        assert result.error_type_code == ErrorCode.INVALID_TYPE
+        assert (
+            result.message
+            == f"ダウンロードした画像のContent-Typeが不正です。ファイル名: {TEST_FILE_NAME}"
         )
 
     def test_handle_s3_not_found(self):
         """S3NotFound例外の処理"""
-        exception = S3NotFound(404, "Not found")
+        exception = S3NotFound()
         result = handle_receipt_exception(exception, TEST_FILE_NAME)
 
-        assert result.status_code == 400
+        assert result.http_status_code == 404
+        assert result.error_type_code == ErrorCode.CLIENT_ERROR
         assert (
-            result.detail
-            == "レシート解析中にエラーが起きました。再度レシートをアップロードしてください。"
+            result.message
+            == f"指定されたファイル名({TEST_FILE_NAME})が見つかりません。ファイルアップロードに問題がある可能性があります。"
         )
 
-    def test_handle_s3_service_unavailable(self):
-        """S3ServiceUnavailable例外の処理"""
-        exception = S3ServiceUnavailable(503, "Service unavailable")
+    def test_handle_openai_response_format_error(self):
+        """OpenAIResponseFormatError例外の処理"""
+        exception = OpenAIResponseFormatError()
         result = handle_receipt_exception(exception, TEST_FILE_NAME)
 
-        assert result.status_code == 503
+        assert result.http_status_code == 503
+        assert result.error_type_code == ErrorCode.SERVER_ERROR
         assert (
-            result.detail
-            == "レシート解析中にエラーが起きました。しばらくしてから再度お試しください。"
+            result.message
+            == "解析結果が予期せぬ形式でした。再度解析をすることで、正常に動作する場合があります。問題が継続する場合は、サポートまでお問い合わせください。"
         )
 
-    def test_handle_s3_forbidden(self):
-        """S3Forbidden例外の処理"""
-        exception = S3Forbidden(403, "Forbidden")
+    @pytest.mark.parametrize(
+        "exception",
+        [S3ServiceUnavailable(), S3InternalServerError(), OpenAIServiceUnavailable()],
+    )
+    def test_handle_service_unavailable(self, exception):
+        """ServiceUnavailable例外の処理"""
         result = handle_receipt_exception(exception, TEST_FILE_NAME)
 
-        assert result.status_code == 500
+        assert result.http_status_code == 503
+        assert result.error_type_code == ErrorCode.SERVER_ERROR
         assert (
-            result.detail
-            == "レシート解析中にエラーが起きました。サポートまでお問い合わせください"
+            result.message
+            == "S3またはOpenAIのサービスが一時的に利用できません。時間をおいて再度お試しください。"
         )
 
-    def test_handle_s3_internal_service_error(self):
-        """S3InternalServiceError例外の処理"""
-        exception = S3InternalServerError(500, "Internal error")
+    def test_handle_s3_bad_request(self):
+        """S3BadRequest例外の処理"""
+        exception = S3BadRequest()
         result = handle_receipt_exception(exception, TEST_FILE_NAME)
 
-        assert result.status_code == 500
+        assert result.http_status_code == 500
+        assert result.error_type_code == ErrorCode.SERVER_ERROR
         assert (
-            result.detail
-            == "レシート解析中にエラーが起きました。しばらくしてから再度お試しください。"
-        )
-
-    def test_handle_s3_unexpected_error(self):
-        """S3UnexpectedError例外の処理"""
-        exception = S3UnexpectedError(500, "Unexpected error")
-        result = handle_receipt_exception(exception, TEST_FILE_NAME)
-
-        assert result.status_code == 500
-        assert (
-            result.detail
+            result.message
             == "レシート解析中にエラーが起きました。しばらくしてから再度お試しください。問題が継続する場合は、サポートまでお問い合わせください"
         )
 
-    def test_handle_unknown_exception(self):
-        """予期せぬ例外の処理"""
-        exception = ValueError("Unknown error")
+    @pytest.mark.parametrize("exception", [S3Forbidden(), OpenAIAuthenticationError()])
+    def test_handle_authentication_exception(self, exception):
+        """S3Forbidden例外の処理"""
         result = handle_receipt_exception(exception, TEST_FILE_NAME)
 
-        assert result.status_code == 500
+        assert result.http_status_code == 500
+        assert result.error_type_code == ErrorCode.SERVER_ERROR
+        assert result.message == "レシート解析中に権限エラーが起きました。"
+
+    @pytest.mark.parametrize(
+        "exception", [S3UnexpectedError(), OpenAIUnexpectedError(), ValueError()]
+    )
+    def test_handle_500_exception(self, exception):
+        """予期せぬ例外の処理"""
+        result = handle_receipt_exception(exception, TEST_FILE_NAME)
+
+        assert result.http_status_code == 500
+        assert result.error_type_code == ErrorCode.SERVER_ERROR
         assert (
-            result.detail
+            result.message
             == "レシート解析中にエラーが起きました。しばらくしてから再度お試しください。問題が継続する場合は、サポートまでお問い合わせください"
         )
 
     def test_handle_exception_with_none_filename(self):
         """filename引数がNoneの場合"""
-        exception = ValueError("Unknown error")
+        exception = ValueError()
         result = handle_receipt_exception(exception, None)
 
-        assert result.status_code == 500
+        assert result.http_status_code == 500
+        assert result.error_type_code == ErrorCode.SERVER_ERROR
         assert (
-            result.detail
+            result.message
             == "レシート解析中にエラーが起きました。しばらくしてから再度お試しください。問題が継続する場合は、サポートまでお問い合わせください"
         )

--- a/tests/test_src/test_analyze.py
+++ b/tests/test_src/test_analyze.py
@@ -52,42 +52,21 @@ def test_get_receipt_detail_success(
 
 
 @pytest.mark.parametrize(
-    "exception, status_code, expected_message",
+    "exception",
     [
-        (
-            OpenAIAuthenticationError,
-            401,
-            "OpenAIの認証に失敗しました。APIキーを確認してください。",
-        ),
-        (
-            OpenAIServiceUnavailable,
-            503,
-            "OpenAIのサービスが一時的に利用できません。時間をおいて再度お試しください。",
-        ),
-        (
-            OpenAIUnexpectedError,
-            500,
-            "OpenAIの予期しないエラーが発生しました。",
-        ),
-        (
-            OpenAIResponseFormatError,
-            503,
-            "OpenAIの応答の解析に失敗しました。",
-        ),
+        OpenAIAuthenticationError,
+        OpenAIServiceUnavailable,
+        OpenAIUnexpectedError,
+        OpenAIResponseFormatError,
     ],
 )
 def test_get_receipt_detail_error_handling(
     mock_openai_handler,
     exception,
-    status_code,
-    expected_message,
 ):
-    mock_openai_handler.analyze_image.side_effect = exception(
-        status_code, expected_message
-    )
+    mock_openai_handler.analyze_image.side_effect = exception
 
     with pytest.raises(exception) as exc_info:
         get_receipt_detail(TEST_IMAGE_BYTES, TEST_IMAGE_TYPE)
 
-    assert exc_info.value.code == status_code
-    assert exc_info.value.message == expected_message
+    assert exc_info.type == exception

--- a/tests/test_src/test_openai.py
+++ b/tests/test_src/test_openai.py
@@ -108,48 +108,36 @@ def test_analyze_image_response_format_error(mock_openai_client):
     with pytest.raises(OpenAIResponseFormatError) as exc_info:
         openai_handler.analyze_image(TEST_BASE64_IMAGE, TEST_IMAGE_TYPE)
 
-    assert exc_info.value.code == 503
-    assert exc_info.value.message == "OpenAIの応答の解析に失敗しました。"
+    assert exc_info.type == OpenAIResponseFormatError
+    assert str(exc_info.value) == "OpenAIのレスポンス形式が不正です"
 
 
 @pytest.mark.parametrize(
-    "exception_type, expected_exception, status_code, expected_message",
+    "exception_type, expected_exception",
     [
         (
             AuthenticationError,
             OpenAIAuthenticationError,
-            401,
-            "OpenAIの認証に失敗しました。APIキーを確認してください。",
         ),
         (
             PermissionDeniedError,
             OpenAIAuthenticationError,
-            401,
-            "OpenAIの認証に失敗しました。APIキーを確認してください。",
         ),
         (
             APITimeoutError,
             OpenAIServiceUnavailable,
-            503,
-            "OpenAIのサービスが一時的に利用できません。時間をおいて再度お試しください。",
         ),
         (
             InternalServerError,
             OpenAIServiceUnavailable,
-            503,
-            "OpenAIのサービスが一時的に利用できません。時間をおいて再度お試しください。",
         ),
         (
             RateLimitError,
             OpenAIServiceUnavailable,
-            503,
-            "OpenAIのサービスが一時的に利用できません。時間をおいて再度お試しください。",
         ),
         (
             Exception,
             OpenAIUnexpectedError,
-            500,
-            "OpenAIの予期しないエラーが発生しました。",
         ),
     ],
 )
@@ -158,8 +146,6 @@ def test_analyze_image_error_handling(
     mock_openai_client,
     exception_type,
     expected_exception,
-    status_code,
-    expected_message,
 ) -> None:
     if exception_type is Exception:
         mock_openai_client.beta.chat.completions.parse.side_effect = exception_type(
@@ -172,15 +158,12 @@ def test_analyze_image_error_handling(
         )
     else:
         # その他のOpenAI例外は特定の引数が必要
-        mock_response = mocker.MagicMock()
-        mock_response.status_code = status_code
         mock_openai_client.beta.chat.completions.parse.side_effect = exception_type(
-            message="OpenAIエラー", response=mock_response, body={}
+            message="OpenAIエラー", response=mocker.MagicMock(), body={}
         )
 
     openai_handler = OpenAIHandler()
     with pytest.raises(expected_exception) as exc_info:
         openai_handler.analyze_image(TEST_BASE64_IMAGE, TEST_IMAGE_TYPE)
 
-    assert exc_info.value.code == status_code
-    assert exc_info.value.message == expected_message
+    assert exc_info.type == expected_exception

--- a/tests/test_src/test_s3_client.py
+++ b/tests/test_src/test_s3_client.py
@@ -14,6 +14,8 @@ from src.receipt_scanner_model.error import (
     S3ServiceUnavailable,
     S3InternalServerError,
     S3UnexpectedError,
+    ContentSizeError,
+    InvalidContentTypeError,
 )
 
 
@@ -134,29 +136,33 @@ def test_file_size_boundary_values(
             "ContentLength": file_size,
             "ContentType": content_type,
         }
-        with pytest.raises(S3BadRequest) as exc_info:
+        with pytest.raises(ContentSizeError) as exc_info:
             s3_client.download_image_by_filename(test_filename)
-        assert exc_info.value.code == 400
-        assert expected_message in exc_info.value.message
+        assert expected_message in str(exc_info.value)
 
 
 @pytest.mark.parametrize(
     "status_code,error_message,expected_exception,expected_message",
     [
-        (400, "Bad Request", S3BadRequest, "不正なリクエストです: Bad Request"),
-        (403, "Forbidden", S3Forbidden, "アクセスが拒否されました: Forbidden"),
-        (404, "Not Found", S3NotFound, "指定されたファイルがS3にありません: Not Found"),
+        (400, "Bad Request", S3BadRequest, "不正なリクエストです: 400 Bad Request"),
+        (403, "Forbidden", S3Forbidden, "アクセスが拒否されました: 403 Forbidden"),
+        (
+            404,
+            "Not Found",
+            S3NotFound,
+            "指定されたファイルがS3にありません: 404 Not Found",
+        ),
         (
             500,
             "Internal Server Error",
             S3InternalServerError,
-            "S3サービスでInternalServerErrorが発生しました: Internal Server Error",
+            "S3サービスでInternalServerErrorが発生しました: 500 Internal Server Error",
         ),
         (
             503,
             "Service Unavailable",
             S3ServiceUnavailable,
-            "S3サービスが一時的に利用できません: Service Unavailable",
+            "S3サービスが一時的に利用できません: 503 Service Unavailable",
         ),
     ],
 )
@@ -184,8 +190,7 @@ def test_download_image_by_filename_client_errors(
     with pytest.raises(expected_exception) as exc_info:
         s3_client.download_image_by_filename(test_file)
 
-    assert exc_info.value.code == status_code
-    assert exc_info.value.message == expected_message
+    assert str(exc_info.value) == expected_message
 
 
 @pytest.mark.parametrize(
@@ -216,10 +221,9 @@ def test_download_image_by_filename_unexpected_client_error(
     with pytest.raises(S3UnexpectedError) as exc_info:
         s3_client.download_image_by_filename(unexpected_client_error_file)
 
-    assert exc_info.value.code == status_code
     assert (
-        exc_info.value.message
-        == f"ダウンロード中に予期しないエラーが発生しました: {error_message}"
+        str(exc_info.value)
+        == f"ダウンロード中に予期しないエラーが発生しました: {status_code} {error_message}"
     )
 
 
@@ -242,9 +246,7 @@ def test_download_image_by_filename_unexpected_error(mock_aws_s3_client, s3_clie
 
     with pytest.raises(S3UnexpectedError) as exc_info:
         s3_client.download_image_by_filename(unexpected_error_file)
-
-    assert exc_info.value.code == 500
-    assert "ダウンロード中に予期しないエラーが発生しました" in exc_info.value.message
+    assert "ダウンロード中に予期しないエラーが発生しました" in str(exc_info.value)
 
 
 def test_head_object_error(mock_aws_s3_client, s3_client):
@@ -290,18 +292,23 @@ def test_unexpected_error(mock_aws_s3_client, s3_client, exception_type, error_m
     with pytest.raises(S3UnexpectedError) as exc_info:
         s3_client.download_image_by_filename(test_filename)
 
-    assert exc_info.value.code == 500
-    assert "ダウンロード中に予期しないエラーが発生しました" in exc_info.value.message
+    assert "ダウンロード中に予期しないエラーが発生しました" in str(exc_info.value)
 
 
 @pytest.mark.parametrize(
-    "file_name, content_type",
+    "file_name, content_type, error_message",
     [
-        ("test_file.pdf", "application/pdf"),
-        ("test_file.gif", "image/gif"),
+        (
+            "test_file.pdf",
+            "application/pdf",
+            "ファイルのContent-Typeが画像ではありません",
+        ),
+        ("test_file.gif", "image/gif", "サポートされていない画像形式です"),
     ],
 )
-def test_invalid_content_type(file_name, content_type, mock_aws_s3_client, s3_client):
+def test_invalid_content_type(
+    mock_aws_s3_client, s3_client, file_name, content_type, error_message
+):
     """Content-Typeが画像でない場合のテスト（lines 68-74のカバレッジ）"""
 
     mock_aws_s3_client.head_object.return_value = {
@@ -309,7 +316,7 @@ def test_invalid_content_type(file_name, content_type, mock_aws_s3_client, s3_cl
         "ContentType": content_type,
     }
 
-    with pytest.raises(S3BadRequest) as exc_info:
+    with pytest.raises(InvalidContentTypeError) as exc_info:
         s3_client.download_image_by_filename(file_name)
 
-    assert exc_info.value.code == 400
+    assert str(exc_info.value) == f"{error_message}: {content_type}"


### PR DESCRIPTION
## 概要

エラーのリスポンスにerror_type_codeを返すようんし、アプリ側のハンドリングをしやすくした。

error_type_codeは下記のように分けた。
``` 
SIZE_ERROR = "size_error"  # 画像サイズエラー
INVALID_TYPE = "invalid_type"  # 画像タイプエラー
CLIENT_ERROR = "client_error"  # 400系
SERVER_ERROR = "server_error"  # 500系
```

## 動作確認

テストを修正し、C1が100%になるようにした

Closes #77 