### PR TITLE
🥅 レシート解析APIのリクエストエラーステータスの修正 (#87)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -34,7 +34,7 @@ app = FastAPI(version=version)
 
 
 @app.exception_handler(CustomHTTPException)
-async def custom_exception_handler(request, exc: CustomHTTPException):
+async def custom_exception_handler(request: Request, exc: CustomHTTPException):
     """CustomHTTPExceptionを構造化されたエラーレスポンスに変換する"""
     return JSONResponse(
         status_code=exc.http_status_code,
@@ -160,18 +160,18 @@ async def root():
 
 
 @app.post("/receipt-analyze")
-def receipt_analyze(request: FileName) -> ReceiptDetail:
+def receipt_analyze(body: FileName) -> ReceiptDetail:
     """S3のファイル名からレシートを解析し、ReceiptDetailを返す
 
     Args:
-        request (FileName): ファイル名
+        body (FileName): ファイル名
 
     Returns:
         ReceiptDetail: 解析したレシート詳細
     """
     filename = None
     try:
-        filename = request.filename
+        filename = body.filename
         # S3Clientを初期化
         s3_client = S3Client()
 

--- a/api/main.py
+++ b/api/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, status
+from fastapi import FastAPI, Request, status
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from src.receipt_scanner_model.analyze import ReceiptDetail, get_receipt_detail
@@ -46,9 +46,33 @@ async def custom_exception_handler(request, exc: CustomHTTPException):
 
 
 @app.exception_handler(RequestValidationError)
-async def validation_exception_handler(request, exc: RequestValidationError):
+async def validation_exception_handler(request: Request, exc: RequestValidationError):
     """RequestValidationErrorをHTTPExceptionの形に変換する"""
     logger.exception("レシート解析中にエラーが起きました。")
+
+    # Content-Typeチェック
+    content_type = request.headers.get("content-type", "")
+    if not content_type.startswith("application/json"):
+        return JSONResponse(
+            status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            content={
+                "error_type_code": ErrorCode.CLIENT_ERROR.value,
+                "message": "リクエストのContent-Typeが不正です。",
+            },
+        )
+
+    error_type = exc.errors()[0]["type"]
+
+    # フィールドの欠落やJSONの不正な場合は400 Bad Requestを返す
+    if error_type in ["missing", "json_invalid"]:
+        return JSONResponse(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            content={
+                "error_type_code": ErrorCode.CLIENT_ERROR.value,
+                "message": "リクエストが不正です。",
+            },
+        )
+
     raise CustomHTTPException(
         http_status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
         error_type_code=ErrorCode.CLIENT_ERROR,

--- a/tests/test_api/test_main.py
+++ b/tests/test_api/test_main.py
@@ -115,15 +115,44 @@ class TestInputValidation:
     リクエスト形式に関するテスト
     """
 
+    # 400 Bad Request
     def test_missing_filename_field(self, client: TestClient):
         """filenameフィールドが欠落"""
         response = client.post("/receipt-analyze", json={})
-        assert response.status_code == 422
+        assert response.status_code == 400
         assert response.json() == {
             "error_type_code": ErrorCode.CLIENT_ERROR.value,
-            "message": "リクエストのバリデーションに失敗しました。入力内容を確認してください。",
+            "message": "リクエストが不正です。",
         }
 
+    def test_invalid_json_format(self, client: TestClient):
+        """不正なJSONフォーマット"""
+        response = client.post(
+            "/receipt-analyze",
+            content="{filename: test.png}",
+            headers={"Content-Type": "application/json"},
+        )
+        assert response.status_code == 400
+        assert response.json() == {
+            "error_type_code": ErrorCode.CLIENT_ERROR.value,
+            "message": "リクエストが不正です。",
+        }
+
+    # 415 Unsupported Media Type
+    def test_invalid_content_type(self, client: TestClient):
+        """Content-Typeが不正"""
+        response = client.post(
+            "/receipt-analyze",
+            json={"filename": TEST_FILE_NAME},
+            headers={"Content-Type": "text/plain"},
+        )
+        assert response.status_code == 415
+        assert response.json() == {
+            "error_type_code": ErrorCode.CLIENT_ERROR.value,
+            "message": "リクエストのContent-Typeが不正です。",
+        }
+
+    # 422 Unprocessable Entity
     @pytest.mark.parametrize("empty_filename", ["", "   "])
     def test_empty_filename(self, client: TestClient, empty_filename):
         """filenameが空文字列"""
@@ -149,32 +178,6 @@ class TestInputValidation:
     def test_invalid_filename_type(self, client: TestClient, invalid_filename):
         """filenameが文字列以外"""
         response = client.post("/receipt-analyze", json={"filename": invalid_filename})
-        assert response.status_code == 422
-        assert response.json() == {
-            "error_type_code": ErrorCode.CLIENT_ERROR.value,
-            "message": "リクエストのバリデーションに失敗しました。入力内容を確認してください。",
-        }
-
-    def test_invalid_json_format(self, client: TestClient):
-        """不正なJSONフォーマット"""
-        response = client.post(
-            "/receipt-analyze",
-            content="{filename: test.png}",
-            headers={"Content-Type": "application/json"},
-        )
-        assert response.status_code == 422
-        assert response.json() == {
-            "error_type_code": ErrorCode.CLIENT_ERROR.value,
-            "message": "リクエストのバリデーションに失敗しました。入力内容を確認してください。",
-        }
-
-    def test_invalid_content_type(self, client: TestClient):
-        """Content-Typeが不正"""
-        response = client.post(
-            "/receipt-analyze",
-            json={"filename": TEST_FILE_NAME},
-            headers={"Content-Type": "text/plain"},
-        )
         assert response.status_code == 422
         assert response.json() == {
             "error_type_code": ErrorCode.CLIENT_ERROR.value,


### PR DESCRIPTION
## 概要

レシート解析APIのリクエストエラーステータスを見直し以下のように修正した。

テスト | 元の期待値 | 修正後
-- | -- | --
2.1 必須フィールド欠落 | 422 | 400
2.2 不正なJSON | 422 | 400
2.3 不正なContent-Type | 422 | 415
2.4 空文字列 | 422 | 422
2.5 null値 | 422 | 422
2.6 不正な型 | 422 | 422
2.7 危険なパターン | 422 | 422

[ドキュメント](https://github.com/ogaogs/receipt-scanner-model/wiki/%E3%83%AC%E3%82%B7%E3%83%BC%E3%83%88%E3%82%B9%E3%82%AD%E3%83%A3%E3%83%8A%E3%83%BCAPI%E3%83%86%E3%82%B9%E3%83%88%E3%82%B1%E3%83%BC%E3%82%B9%E3%83%89%E3%82%AD%E3%83%A5%E3%83%A1%E3%83%B3%E3%83%88)も更新し、テストが通り、C1カバレッジが100%なことを確認した

closes #87 